### PR TITLE
Correctly denote the optional arguments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ Takes a new precision, and an optional rounding strategy.  Returns a new number 
 number('14.556').changePrecision(2, number.trim).toString() // => '14.55'
 ```
 
-#### `numberValue.toString([[displayPrecision], roundingStrategy])`
+#### `numberValue.toString([displayPrecision, [roundingStrategy]])`
 
 Returns a string representation of the number for display or storage.  You can specify the precision and rounding strategy to be passed to `changePrecision` if you like - by default, the number will display at its current precision.  See [Rounding](#rounding)
 


### PR DESCRIPTION
Previously it showed that you could add a `roundingStrategy` without passing a `displayPrecision`.

It looks like you can technically do that in the code, but the rounding function doesn't get used.

```js
number('123.456').toString()
number('123.456').toString(Math.round)      // function will not be used, and will be ignored
number('123.456').toString(2)              // round to 2 decimals
number('123.456').toString(2, Math.round) // function gets used
```

So I think the readme shows the correct brackets now.