### PR TITLE
Add test for javascript numbers

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -119,3 +119,8 @@ test(`modulo`, t => {
 
 	t.end()
 })
+
+test(`works with javascript numbers too`, t => {
+	t.equal(number(3).times(4).toString(), `12`)
+	t.end()
+})


### PR DESCRIPTION
The docs say that it supports a string...  But is seems to support js numbers too.  And people are gonna pass in JS numbers unless it's forbidden.  So to avoid an accidental behavior-breaking change in the future, I figured I'd add a test.

In semver, since you documented that functions require strings, I suppose it wouldn't require a major version bump if you disallowed js numbers as inputs.  In practice, that feels kinda wrong.

**Note** I ran the tests locally and they passed, including my new test.