### PR TITLE
fix: add package.json as named export

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     ".": {
       "require": "./index.cjs",
       "import": "./index.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test:node": "tsm test/test.ts | tap-color",


### PR DESCRIPTION
Not a huge priority, but Rollup (specifically the Svelte plugin) keeps complaining because I'm using it in a Svelte component and it can't introspect to see if it can be optimized.